### PR TITLE
[PROPOSAL] Add filter like django orm style for repositories

### DIFF
--- a/flask_toolkit/shared/repository.py
+++ b/flask_toolkit/shared/repository.py
@@ -1,12 +1,35 @@
 import logging
-from sqlalchemy.exc import DataError
-from flask_toolkit.shared.exceptions import ObjectDoesNotExistException
 from flask_toolkit.infra.domain_event import bus
+from flask_toolkit.shared.exceptions import ObjectDoesNotExistException
+from sqlalchemy.exc import DataError
+from sqlalchemy.orm.base import _entity_descriptor
+from sqlalchemy.sql import extract, operators
+from sqlalchemy.util import to_list
 from .storage import Storage
 
 
 class Repository(object):
     _entity = None
+
+    __filter_operators__ = {
+        'contains': operators.contains_op,
+        'day': lambda c, x: extract('day', c) == x,
+        'endswith': operators.endswith_op,
+        'exact': operators.eq,
+        'gt': operators.gt,
+        'gte': operators.ge,
+        'iendswith': lambda c, x: c.ilike('%' + x.replace('%', '%%')),
+        'iexact': operators.ilike_op,
+        'in': operators.in_op,
+        'isnull': lambda c, x: x and c != None or c == None,
+        'istartswith': lambda c, x: c.ilike(x.replace('%', '%%') + '%'),
+        'le': operators.le,
+        'lte': operators.lt,
+        'month': lambda c, x: extract('month', c) == x,
+        'range': operators.between_op,
+        'startswith': operators.startswith_op,
+        'year': lambda c, x: extract('year', c) == x,
+    }
 
     def __init__(self):
         try:
@@ -41,6 +64,35 @@ class Repository(object):
             entity = self._entity
 
         return self.session.query(entity)
+
+    def filter(self, **kwargs):
+        return self._filter_or_exclude(negate=False, kwargs=kwargs)
+
+    def exclude(self, **kwargs):
+        return self._filter_or_exclude(negate=True, kwargs=kwargs)
+
+    def _filter_or_exclude(self, negate, kwargs):
+        q = self.query()
+        negate_if = lambda expr: expr if not negate else ~expr
+        column = None
+        for arg, value in kwargs.items():
+            for token in arg.split('__'):
+                if column is None:
+                    column = _entity_descriptor(q._joinpoint_zero(), token)
+                    if column.impl.uses_objects:
+                        q = q.join(column)
+                        column = None
+                elif token in self.__filter_operators__:
+                    op = self.__filter_operators__[token]
+                    q = q.filter(negate_if(op(column, *to_list(value))))
+                    column = None
+                else:
+                    raise ValueError('No idea what to do with %r' % token)
+            if column is not None:
+                q = q.filter(negate_if(column == value))
+                column = None
+            q = q.reset_joinpoint()
+        return q
 
     def __dispatch_domain_events(self, entity):
         for event in entity.domain_events:


### PR DESCRIPTION
Precisamos de um `filter` para os nossos repositories, e achei uma reiceitinha de como transformar o filter do `sqlalchemy` no `django orm style`.

A ideia é simplificar as consultas e deixar isso interoperável entre ferramentas do mesmo estilo de `sqlalchemy`.

Exemplo:

```python
RepositoryFoo().filter(foo__contains='teste', bar__isnull=True, size__gte=10, ...)
```
Operators:

```- contains -> field__contains
- day -> field__day
- endswith -> field__endswith
- exact -> field__exact
- gt -> field__gt
- gte -> field__gte
- iendswith -> field__iendswith
- iexact -> field__iexact
- in -> field__in
- isnull -> field__isnull
- istartswith -> field__istartswith
- le -> field__le
- lte -> field__lte
- month -> field__month
- range -> field__range
- startswith -> field__startswith
- year -> field__year
```
Acho que pode simplificar e economizar algumas linhas. :nail_care: 