### PR TITLE
Remove exception error handler

### DIFF
--- a/flask_toolkit/application.py
+++ b/flask_toolkit/application.py
@@ -76,11 +76,6 @@ def create_application(name='app-python', config=dict(), db=None, config_logging
     def invalid_domain_conditions(error):
         return jsonify({'errors': [str(error)]}), 422
 
-    @app.errorhandler(Exception)
-    def internal_server_error(error):
-        app.logger.exception(error)
-        return 'Something bad happened', 500
-
     CORS(app)
     RequestID(app)
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="flask_toolkit",
-    version="0.0.15",
+    version="0.0.16",
     author="Aurelio Saraiva",
     author_email="aurelio.saraiva@creditas.com.br",
     description="Flask toolkit for Domain Driven Design (DDD)",


### PR DESCRIPTION
## Por que?
Quando usamos o `abort` do flask ele levanta uma exception, acontece que com esse handler qualquer exception levantada ele da 500. Então mesmo dando `abort(400)` ele acaba dando 500.

Removi pois não faz sentido ter esse handler já que se acontecer qualquer erro inesperado ele já vai retornar 500. E a mensagem `Something bad happened` não falava nada! :sweat_smile: 