### PR TITLE
Add 'to_dict()" function to entity class

### DIFF
--- a/flask_toolkit/shared/entity.py
+++ b/flask_toolkit/shared/entity.py
@@ -7,6 +7,7 @@ class Entity:
                 setattr(self, key, kwargs[key])
 
     def add_domain_event(self, event):
+        import ipdb; ipdb.set_trace()
         self.domain_events.append(event)
 
     def remove_domain_event(self, event):
@@ -23,3 +24,6 @@ class Entity:
         attributes = sorted(self.__dict__.items(), key=lambda tuple_: tuple_[0])
         attributes = [f'{key}={value!r}' for key, value in attributes if not key.startswith('_')]
         return f'<{self.__class__.__name__}({", ".join(attributes)})>'
+
+    def to_dict(self):
+        return self.__dict__

--- a/flask_toolkit/shared/entity.py
+++ b/flask_toolkit/shared/entity.py
@@ -7,7 +7,6 @@ class Entity:
                 setattr(self, key, kwargs[key])
 
     def add_domain_event(self, event):
-        import ipdb; ipdb.set_trace()
         self.domain_events.append(event)
 
     def remove_domain_event(self, event):


### PR DESCRIPTION
O propósito desse PR é apenas adicionar o recurso `to_dict()` à Classe `Entity` e seus filhos, isto é, as entidades de domínio.

Isso porque no código do Hermes, foi preciso usar o `__dict__` em uma entity `Contact`, então, faz-se útil.